### PR TITLE
feat: Add Redis adapter and integrate with ORM

### DIFF
--- a/examples/simple-usage.ts
+++ b/examples/simple-usage.ts
@@ -1,6 +1,6 @@
 // To run this example:
 // 1. Ensure you have ts-node installed (npm install -g ts-node)
-// 2. Ensure you have the necessary database drivers installed (npm install mongodb mysql2 pg)
+// 2. Ensure you have the necessary database drivers installed (npm install mongodb mysql2 pg redis)
 // 3. From the root of the project, run: ts-node examples/simple-usage.ts
 
 import { 
@@ -9,8 +9,8 @@ import {
   DatabaseType,
   MongoDBAdapter, // For instanceof checks
   MySQLAdapter,   // For instanceof checks
-  PostgresAdapter // For instanceof checks
-  // Model is not directly used in this basic example but would be in a real app
+  PostgresAdapter, // For instanceof checks
+  RedisAdapter // Added RedisAdapter for instanceof check
 } from '../src'; // Adjusted import path
 
 // Example: Configuration for MongoDB
@@ -36,29 +36,29 @@ const postgresConfig = {
   port: 5432,
 };
 
+// Example: Configuration for Redis
+const redisConfig = {
+  url: process.env.TEST_REDIS_URL || 'redis://localhost:6379', // Use environment variable if available
+};
+
 async function main() {
   console.log('Demonstrating DatabaseAdapterFactory from library exports...');
 
   // --- MongoDB Example ---
   try {
     console.log('\n--- MongoDB Example ---');
-    // Config is for the adapter's connect method, not the factory's createAdapter method.
     const mongoAdapter = DatabaseAdapterFactory.createAdapter(
       DatabaseType.MONGODB,
-      {} // Pass empty config or specific config if adapter constructor needs it
+      {} 
     );
     
     if (mongoAdapter instanceof MongoDBAdapter) {
       console.log('MongoDBAdapter created successfully via factory.');
       const ormWithMongo = new ORM(mongoAdapter);
       console.log('ORM instantiated with MongoDBAdapter.');
-      
-      // To actually connect (optional, for demonstration):
-      // console.log('Attempting to connect to MongoDB (example)...');
       // await mongoAdapter.connect(mongoConfig);
       // console.log('Connected to MongoDB (example).');
       // await mongoAdapter.disconnect();
-      // console.log('Disconnected from MongoDB (example).');
     } else {
       console.error('Failed to create MongoDBAdapter correctly.');
     }
@@ -78,12 +78,9 @@ async function main() {
       console.log('MySQLAdapter created successfully via factory.');
       const ormWithMysql = new ORM(mysqlAdapter);
       console.log('ORM instantiated with MySQLAdapter.');
-      // To actually connect (optional, for demonstration):
-      // console.log('Attempting to connect to MySQL (example)...');
       // await mysqlAdapter.connect(mysqlConfig);
       // console.log('Connected to MySQL (example).');
       // await mysqlAdapter.disconnect();
-      // console.log('Disconnected from MySQL (example).');
     } else {
       console.error('Failed to create MySQLAdapter correctly.');
     }
@@ -103,12 +100,9 @@ async function main() {
       console.log('PostgresAdapter created successfully via factory.');
       const ormWithPostgres = new ORM(postgresAdapter);
       console.log('ORM instantiated with PostgresAdapter.');
-      // To actually connect (optional, for demonstration):
-      // console.log('Attempting to connect to PostgreSQL (example)...');
       // await postgresAdapter.connect(postgresConfig);
       // console.log('Connected to PostgreSQL (example).');
       // await postgresAdapter.disconnect();
-      // console.log('Disconnected from PostgreSQL (example).');
     } else {
       console.error('Failed to create PostgresAdapter correctly.');
     }
@@ -116,18 +110,55 @@ async function main() {
     console.error('Error in PostgreSQL example:', error);
   }
 
+  // --- Redis Example ---
+  try {
+    console.log('\n--- Redis Example ---');
+    const redisAdapter = DatabaseAdapterFactory.createAdapter(
+      DatabaseType.REDIS,
+      {} // Config is for connect method, not constructor here
+    );
+
+    if (redisAdapter instanceof RedisAdapter) {
+      console.log('RedisAdapter created successfully via factory.');
+      const ormWithRedis = new ORM(redisAdapter);
+      console.log('ORM instantiated with RedisAdapter.');
+
+      // Example usage (optional, requires Redis server)
+      // console.log('Attempting to connect to Redis (example)...');
+      // await redisAdapter.connect(redisConfig); // Pass full config here
+      // console.log('Connected to Redis (example).');
+
+      // const PKey = 'exampleUser'; // Key prefix for this example
+      // const userId = 'user123';
+      
+      // console.log(`Inserting item with ID ${userId} into Redis...`);
+      // await ormWithRedis.insert(PKey, { id: userId, name: 'Redis User', email: 'redis@example.com' });
+      // console.log('Item inserted.');
+
+      // console.log(`Finding item with ID ${userId} from Redis...`);
+      // const userFromRedis = await ormWithRedis.findOne(PKey, { id: userId });
+      // console.log('Found item:', userFromRedis);
+
+      // await redisAdapter.disconnect();
+      // console.log('Disconnected from Redis (example).');
+    } else {
+      console.error('Failed to create RedisAdapter correctly.');
+    }
+  } catch (error) {
+    console.error('Error in Redis example:', error);
+  }
+
   // --- Error Handling Example for Unsupported Type ---
   try {
     console.log('\n--- Unsupported Type Example ---');
     const unsupportedAdapter = DatabaseAdapterFactory.createAdapter(
-      'unsupported_db_type' as DatabaseType, // Force type for testing
+      'unsupported_db_type' as DatabaseType, 
       {},
     );
-    // This line should not be reached if error handling in the factory works.
     console.log('Created adapter for unsupported type (this indicates an issue):', unsupportedAdapter);
   } catch (error: any) {
     console.log('Correctly caught error for unsupported type:');
-    console.error(error.message); // Displaying the error message
+    console.error(error.message); 
   }
   
   console.log('\nFactory demonstration complete.');

--- a/package.json
+++ b/package.json
@@ -22,12 +22,15 @@
     "dependencies": {
         "mongodb": "^6.0.0",
         "mysql2": "^3.0.0",
-        "pg": "^8.0.0"
+        "pg": "^8.0.0",
+        "redis": "^4.6.10",
+        "uuid": "^9.0.0"
     },
     "devDependencies": {
         "@types/jest": "^29.0.0",
         "@types/node": "^20.0.0",
         "@types/pg": "^8.0.0",
+        "@types/uuid": "^9.0.0",
         "eslint": "^8.0.0",
         "eslint-plugin-import": "^2.25.0",
         "eslint-plugin-promise": "^6.0.0",

--- a/src/adapters/RedisAdapter.ts
+++ b/src/adapters/RedisAdapter.ts
@@ -1,0 +1,126 @@
+import { createClient, RedisClientType, RedisClientOptions } from 'redis';
+import { DatabaseAdapter } from './DatabaseAdapter';
+import { v4 as uuidv4 } from 'uuid';
+
+export class RedisAdapter implements DatabaseAdapter {
+  private client: RedisClientType | null = null;
+  private isConnected: boolean = false;
+
+  constructor() { /* Constructor */ }
+  private _getKey(prefix: string, id: string): string { return `${prefix}:${id}`; }
+  
+  async connect(config: RedisClientOptions | { url: string } | undefined): Promise<void> { 
+    if (this.isConnected && this.client) return;
+    try {
+      this.client = createClient(config);
+      this.client.on('error', (err) => { console.error('Redis Client Error', err); this.isConnected = false; });
+      this.client.on('ready', () => { this.isConnected = true; console.log('Redis client connected and ready.'); });
+      this.client.on('end', () => { this.isConnected = false; console.log('Redis client connection closed.'); });
+      await this.client.connect();
+    } catch (error) { console.error('Failed to connect to Redis:', error); this.isConnected = false; this.client = null; throw error; }
+  }
+  
+  async disconnect(): Promise<void> { 
+    if (this.client && this.isConnected) {
+      try { await this.client.quit(); console.log('Disconnected from Redis.'); }
+      catch (error) { console.error('Error during Redis disconnection:', error); }
+      finally { this.isConnected = false; this.client = null; }
+    }
+  }
+  
+  async insert(keyPrefix: string, data: any): Promise<any> { 
+    if (!this.client || !this.isConnected) throw new Error('Redis client not connected.');
+    const id = data.id || uuidv4();
+    const key = this._getKey(keyPrefix, id);
+    const dataToStore = { ...data, id };
+    try { await this.client.set(key, JSON.stringify(dataToStore)); return id; }
+    catch (error) { console.error(`Error inserting data for key ${key}:`, error); throw error; }
+  }
+  
+  async findOne(keyPrefix: string, criteria: any): Promise<any | null> { 
+    if (!this.client || !this.isConnected) throw new Error('Redis client not connected.');
+    if (!criteria || typeof criteria.id === 'undefined') throw new Error('findOne requires "id" in criteria.');
+    const key = this._getKey(keyPrefix, criteria.id);
+    try { const result = await this.client.get(key); return result ? JSON.parse(result) : null; }
+    catch (error) { console.error(`Error finding data for key ${key}:`, error); throw error; }
+  }
+  
+  async find(keyPrefix: string, criteria: any): Promise<any[]> { 
+    if (!this.client || !this.isConnected) throw new Error('Redis client not connected.');
+    try {
+      const keys = await this.client.keys(`${keyPrefix}:*`);
+      if (!keys || keys.length === 0) return [];
+      const results = await this.client.mGet(keys);
+      const objects = results.filter(res => res !== null).map(res => JSON.parse(res!));
+      if (criteria && Object.keys(criteria).length > 0) {
+        return objects.filter(obj => Object.entries(criteria).every(([k, v]) => obj.hasOwnProperty(k) && obj[k] === v));
+      }
+      return objects;
+    } catch (error) { console.error(`Error finding data for prefix ${keyPrefix}:`, error); throw error; }
+  }
+
+  /**
+   * Updates a record in Redis, identified by ID in criteria.
+   * @param keyPrefix Prefix for the key.
+   * @param criteria Must contain an 'id' field to identify the record.
+   * @param data Data to update. This will overwrite the existing record.
+   * @returns Number of records updated (1 if successful and ID found, 0 otherwise).
+   */
+  async update(keyPrefix: string, criteria: any, data: any): Promise<number> {
+    if (!this.client || !this.isConnected) {
+      throw new Error('Redis client not connected.');
+    }
+    if (!criteria || typeof criteria.id === 'undefined') {
+      throw new Error('Update in RedisAdapter requires an "id" in criteria.');
+    }
+
+    const key = this._getKey(keyPrefix, criteria.id);
+    
+    try {
+      // Check if key exists to report accurate "updated" count
+      const exists = await this.client.exists(key);
+      if (exists === 0) { // client.exists returns number of keys that exist
+        return 0; // Record not found, nothing to update
+      }
+      
+      // Ensure the ID from criteria is preserved in the new data
+      const dataToStore = { ...data, id: criteria.id }; 
+      await this.client.set(key, JSON.stringify(dataToStore));
+      return 1; // Successfully updated 1 record
+    } catch (error) {
+      console.error(`Error updating data in Redis for key ${key}:`, error);
+      throw error;
+    }
+  }
+
+  /**
+   * Deletes a record from Redis by ID.
+   * @param keyPrefix Prefix for the key.
+   * @param criteria Must contain an 'id' field.
+   * @returns Number of records deleted (1 if successful, 0 if key not found).
+   */
+  async delete(keyPrefix: string, criteria: any): Promise<number> {
+    if (!this.client || !this.isConnected) {
+      throw new Error('Redis client not connected.');
+    }
+    if (!criteria || typeof criteria.id === 'undefined') {
+      throw new Error('Delete in RedisAdapter requires an "id" in criteria.');
+    }
+
+    const key = this._getKey(keyPrefix, criteria.id);
+    try {
+      const result = await this.client.del(key);
+      return result; // Returns the number of keys that were removed.
+    } catch (error) {
+      console.error(`Error deleting data in Redis for key ${key}:`, error);
+      throw error;
+    }
+  }
+
+  async query(queryString: string, params?: any[]): Promise<any[]> {
+    // To be implemented (could be for raw Redis commands)
+    // For now, let's make it clear it's not the same as SQL query
+    console.warn('The "query" method in RedisAdapter is intended for raw Redis commands and is not fully implemented for general purpose querying like SQL adapters.');
+    throw new Error('Method not implemented or not applicable for general queries in RedisAdapter.');
+  }
+}

--- a/src/factories/DatabaseAdapterFactory.ts
+++ b/src/factories/DatabaseAdapterFactory.ts
@@ -2,27 +2,33 @@ import { DatabaseAdapter } from '../adapters/DatabaseAdapter';
 import { MongoDBAdapter } from '../adapters/MongoDBAdapter';
 import { MySQLAdapter } from '../adapters/MySQLAdapter';
 import { PostgresAdapter } from '../adapters/PostgresAdapter';
+import { RedisAdapter } from '../adapters/RedisAdapter'; // Import RedisAdapter
 
 export enum DatabaseType {
   MONGODB = 'mongodb',
   MYSQL = 'mysql',
   POSTGRESQL = 'postgresql',
+  REDIS = 'redis',
 }
 
 export class DatabaseAdapterFactory {
   public static createAdapter(
     type: DatabaseType,
-    config: any,
+    config: any, // Config is primarily for the connect method of the adapter
   ): DatabaseAdapter {
     switch (type) {
       case DatabaseType.MONGODB:
-        return new MongoDBAdapter(); // Configuration will be passed during connect()
+        return new MongoDBAdapter();
       case DatabaseType.MYSQL:
-        return new MySQLAdapter(); // Configuration will be passed during connect()
+        return new MySQLAdapter();
       case DatabaseType.POSTGRESQL:
-        return new PostgresAdapter(); // Configuration will be passed during connect()
+        return new PostgresAdapter();
+      case DatabaseType.REDIS: // Added this case
+        return new RedisAdapter();
       default:
-        throw new Error(`Unsupported database type: ${type}`);
+        // Ensure 'never' type for exhaustive check if possible, or robust default
+        const exhaustiveCheck: never = type; 
+        throw new Error(`Unsupported database type: ${exhaustiveCheck}`);
     }
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ export type { DatabaseAdapter } from './adapters/DatabaseAdapter'; // Exporting 
 export { MongoDBAdapter } from './adapters/MongoDBAdapter';
 export { MySQLAdapter } from './adapters/MySQLAdapter';
 export { PostgresAdapter } from './adapters/PostgresAdapter';
+export { RedisAdapter } from './adapters/RedisAdapter';
 
 // It's also common to export everything from a module if needed
 // export * from './orm/ORM';

--- a/tests/adapters/RedisAdapter.spec.ts
+++ b/tests/adapters/RedisAdapter.spec.ts
@@ -1,0 +1,146 @@
+import { RedisAdapter } from '../../src/adapters/RedisAdapter';
+// DatabaseAdapter might not be needed directly in tests unless for type casting
+// import { DatabaseAdapter } from '../../src/adapters/DatabaseAdapter'; 
+import { v4 as uuidv4 } from 'uuid';
+
+describe('RedisAdapter Integration Tests', () => {
+  let adapter: RedisAdapter;
+  const redisConfig = { url: process.env.TEST_REDIS_URL || 'redis://localhost:6379' };
+  const testKeyPrefix = 'test_items_crud'; // Use a distinct prefix for these tests
+  let testItemId: string; // To store ID of item created in one test and used in another
+
+  beforeAll(async () => {
+    // One-time setup: connect and potentially clean the prefix
+    adapter = new RedisAdapter();
+    await adapter.connect(redisConfig);
+    // Initial cleanup for the specific prefix (safer than FLUSHDB)
+    // This requires direct client access or a helper method.
+    // For now, assuming direct client access for cleanup if possible.
+    // This is a simplified representation of cleanup.
+    const client = (adapter as any).client; // Accessing private client for test cleanup
+    if (client) {
+      const keys = await client.keys(`${testKeyPrefix}:*`);
+      if (keys.length > 0) await client.del(keys);
+    }
+  });
+
+  afterAll(async () => {
+    // Final cleanup and disconnect
+    const client = (adapter as any).client;
+    if (client) {
+      const keys = await client.keys(`${testKeyPrefix}:*`);
+      if (keys.length > 0) await client.del(keys);
+    }
+    if (adapter) {
+      await adapter.disconnect();
+    }
+  });
+  
+  // Removed beforeEach/afterEach in favor of beforeAll/afterAll for this test structure
+  // to allow data to persist between specific tests (e.g. insert then findOne).
+
+  it('should connect to Redis (covered by beforeAll)', () => {
+    expect(adapter).toBeInstanceOf(RedisAdapter);
+    // We need a way to check if client.isOpen or similar is true
+    // For now, we assume connection if beforeAll didn't throw.
+    const client = (adapter as any).client;
+    expect(client?.isOpen).toBe(true); // Check if client is connected
+  });
+
+  it('should insert an item and return an ID', async () => {
+    const testData = { name: 'Test Item 1', value: 100 };
+    testItemId = await adapter.insert(testKeyPrefix, testData); // Store ID for later tests
+    expect(testItemId).toBeDefined();
+  });
+  
+  it('should insert an item with a pre-defined ID', async () => {
+    const predefinedId = uuidv4();
+    const testData = { id: predefinedId, name: 'Test Item Predefined', value: 456 };
+    const returnedId = await adapter.insert(testKeyPrefix, testData);
+    expect(returnedId).toEqual(predefinedId);
+    // No need to store this ID globally as it's self-contained
+  });
+
+  it('should find a single item by ID (findOne)', async () => {
+    // This test depends on the 'insert' test above having run and set testItemId
+    expect(testItemId).toBeDefined(); // Ensure testItemId is set
+    const item = await adapter.findOne(testKeyPrefix, { id: testItemId });
+    expect(item).not.toBeNull();
+    expect(item.id).toEqual(testItemId);
+    expect(item.name).toEqual('Test Item 1'); // From the first insert test
+  });
+
+  it('should return null if findOne does not find an item by ID', async () => {
+    const nonExistentId = uuidv4();
+    const item = await adapter.findOne(testKeyPrefix, { id: nonExistentId });
+    expect(item).toBeNull();
+  });
+
+  it('should find multiple items (find)', async () => {
+    // Insert a couple more items for find test
+    const item2Id = uuidv4();
+    await adapter.insert(testKeyPrefix, { id: item2Id, name: 'Test Item 2', category: 'A' });
+    await adapter.insert(testKeyPrefix, { id: uuidv4(), name: 'Another Item', category: 'B' }); // Will be found by prefix
+    
+    const allItems = await adapter.find(testKeyPrefix, {});
+    // Expect at least 3 items: testItemId, item2Id, and the predefinedId one, plus 'Another Item'
+    expect(allItems.length).toBeGreaterThanOrEqual(3); 
+    expect(allItems.some(item => item.id === testItemId)).toBe(true);
+    expect(allItems.some(item => item.id === item2Id)).toBe(true);
+
+    // Test find with criteria (client-side filtering)
+    const categoryAItems = await adapter.find(testKeyPrefix, { category: 'A' });
+    expect(categoryAItems.length).toBeGreaterThanOrEqual(1);
+    expect(categoryAItems.every(item => item.category === 'A')).toBe(true);
+    expect(categoryAItems.some(item => item.id === item2Id)).toBe(true);
+  });
+  
+  it('should update an existing item by ID (update)', async () => {
+    expect(testItemId).toBeDefined();
+    const updatedName = 'Updated Test Item 1';
+    const updateResult = await adapter.update(testKeyPrefix, { id: testItemId }, { name: updatedName, value: 101 });
+    expect(updateResult).toEqual(1); // 1 record updated
+
+    const updatedItem = await adapter.findOne(testKeyPrefix, { id: testItemId });
+    expect(updatedItem).not.toBeNull();
+    expect(updatedItem!.name).toEqual(updatedName);
+    expect(updatedItem!.value).toEqual(101);
+  });
+
+  it('should return 0 if update targets a non-existent ID', async () => {
+    const nonExistentId = uuidv4();
+    const updateResult = await adapter.update(testKeyPrefix, { id: nonExistentId }, { name: 'Non Existent' });
+    expect(updateResult).toEqual(0);
+  });
+
+  it('should delete an item by ID (delete)', async () => {
+    expect(testItemId).toBeDefined();
+    const deleteResult = await adapter.delete(testKeyPrefix, { id: testItemId });
+    expect(deleteResult).toEqual(1); // 1 record deleted
+
+    const deletedItem = await adapter.findOne(testKeyPrefix, { id: testItemId });
+    expect(deletedItem).toBeNull();
+  });
+
+  it('should return 0 if delete targets a non-existent ID', async () => {
+    const nonExistentId = uuidv4();
+    const deleteResult = await adapter.delete(testKeyPrefix, { id: nonExistentId });
+    expect(deleteResult).toEqual(0);
+  });
+
+  it('should throw error for findOne if id is not in criteria', async () => {
+    await expect(adapter.findOne(testKeyPrefix, { name: 'some name' }))
+      .rejects.toThrow('findOne in RedisAdapter requires an "id" in criteria for direct lookup.');
+  });
+
+  it('should throw error for update if id is not in criteria', async () => {
+    await expect(adapter.update(testKeyPrefix, { name: 'some name' }, { value: 1 }))
+      .rejects.toThrow('Update in RedisAdapter requires an "id" in criteria.');
+  });
+
+  it('should throw error for delete if id is not in criteria', async () => {
+    await expect(adapter.delete(testKeyPrefix, { name: 'some name' }))
+      .rejects.toThrow('Delete in RedisAdapter requires an "id" in criteria.');
+  });
+
+});

--- a/tests/factories/DatabaseAdapterFactory.spec.ts
+++ b/tests/factories/DatabaseAdapterFactory.spec.ts
@@ -3,10 +3,11 @@ import { DatabaseAdapter } from '../../src/adapters/DatabaseAdapter';
 import { MongoDBAdapter } from '../../src/adapters/MongoDBAdapter';
 import { MySQLAdapter } from '../../src/adapters/MySQLAdapter';
 import { PostgresAdapter } from '../../src/adapters/PostgresAdapter';
+import { RedisAdapter } from '../../src/adapters/RedisAdapter'; // Import RedisAdapter
 
 describe('DatabaseAdapterFactory', () => {
   // Mock config, not strictly needed for factory createAdapter as config is passed to connect later
-  const mockConfig = {};
+  const mockConfig = {}; // This can be an empty object as adapters expect config in connect()
 
   it('should create a MongoDBAdapter for MONGODB type', () => {
     const adapter = DatabaseAdapterFactory.createAdapter(DatabaseType.MONGODB, mockConfig);
@@ -26,14 +27,30 @@ describe('DatabaseAdapterFactory', () => {
     expect(adapter).toBeInstanceOf(DatabaseAdapter);
   });
 
+  // Add this new test case for RedisAdapter
+  it('should create a RedisAdapter for REDIS type', () => {
+    const adapter = DatabaseAdapterFactory.createAdapter(DatabaseType.REDIS, mockConfig);
+    expect(adapter).toBeInstanceOf(RedisAdapter);
+    expect(adapter).toBeInstanceOf(DatabaseAdapter);
+  });
+
   it('should throw an error for an unsupported database type', () => {
     const unsupportedType = 'UNSUPPORTED_DB_TYPE' as DatabaseType; // Cast for testing
+    // The error message now includes the unsupported type value due to exhaustiveCheck logic
     expect(() => {
       DatabaseAdapterFactory.createAdapter(unsupportedType, mockConfig);
-    }).toThrowError(`Unsupported database type: ${unsupportedType}`);
+    }).toThrowError(`Unsupported database type: ${unsupportedType}`); 
+    // If the factory's default case doesn't use the exhaustiveCheck variable in the error string, 
+    // adjust the expected error message accordingly.
+    // The current factory implementation uses: `throw new Error(\`Unsupported database type: \${exhaustiveCheck}\`);`
+    // So, this test should be correct.
   });
 
   it('should throw an error if the type is null or undefined', () => {
+    // The error message might change slightly if the exhaustiveCheck logic affects how null/undefined are stringified.
+    // Current factory: `throw new Error(\`Unsupported database type: \${exhaustiveCheck}\`);`
+    // When type is null, exhaustiveCheck is null. Error: "Unsupported database type: null"
+    // When type is undefined, exhaustiveCheck is undefined. Error: "Unsupported database type: undefined"
     expect(() => {
       DatabaseAdapterFactory.createAdapter(null as any, mockConfig);
     }).toThrowError('Unsupported database type: null');

--- a/tests/index.exports.spec.ts
+++ b/tests/index.exports.spec.ts
@@ -38,10 +38,16 @@ describe('Library Exports', () => {
     expect(AllExports.PostgresAdapter).toBeDefined();
   });
 
+  // Add this new test case
+  it('should export RedisAdapter class', () => {
+    expect(AllExports.RedisAdapter).toBeDefined();
+  });
+
   // Verify a few specific enum values if necessary
   it('DatabaseType enum should have correct values', () => {
     expect(AllExports.DatabaseType.MONGODB).toEqual('mongodb');
     expect(AllExports.DatabaseType.MYSQL).toEqual('mysql');
     expect(AllExports.DatabaseType.POSTGRESQL).toEqual('postgresql');
+    expect(AllExports.DatabaseType.REDIS).toEqual('redis'); // Add check for REDIS
   });
 });


### PR DESCRIPTION
Adds support for Redis as a database backend.

Key changes include:
- Added `redis` (node-redis v4) client library as a dependency.
- Implemented `RedisAdapter` in `src/adapters/RedisAdapter.ts`, providing methods for connect, disconnect, insert, findOne, find (using KEYS), update, and delete. Data is stored as JSON strings with UUIDs for IDs if not provided.
- Updated `DatabaseAdapterFactory` and `DatabaseType` enum to support `RedisAdapter`.
- Created comprehensive integration tests for `RedisAdapter` in `tests/adapters/RedisAdapter.spec.ts`, covering CRUD operations and connection management.
- Exported `RedisAdapter` from the library's main entry point (`src/index.ts`).
- Added an example of `RedisAdapter` usage in `examples/simple-usage.ts`.
- Updated factory tests and library export tests to include `RedisAdapter`.

This enhancement broadens the library's applicability by enabling interaction with Redis key-value stores.